### PR TITLE
Updated to use run_on_changes() rather than run_on_change()

### DIFF
--- a/guard-sunspot.gemspec
+++ b/guard-sunspot.gemspec
@@ -5,9 +5,9 @@ require "guard/sunspot/version"
 Gem::Specification.new do |s|
   s.name        = "guard-sunspot"
   s.version     = Guard::SunspotVersion::VERSION
-  s.authors     = ["John Hampton"]
-  s.email       = ["john@topagentnetwork.com"]
-  s.homepage    = "http://github.com/cleanoffer/guard-sunspot"
+  s.authors     = ["John Hampton", "Anthony Smith"]
+  s.email       = ["john@topagentnetwork.com", "anthony@sticksnleaves.com"]
+  s.homepage    = "http://github.com/anthonator/guard-sunspot"
   s.summary     = 'Guard gem for sunspot solr'
   s.description = 'Guard::Sunspot automatically starts and stops your solr server.'
 

--- a/lib/guard/sunspot.rb
+++ b/lib/guard/sunspot.rb
@@ -25,7 +25,7 @@ module Guard
       start
     end
 
-    def run_on_change(path)
+    def run_on_changes(path)
       reload
     end
   end

--- a/lib/guard/sunspot/version.rb
+++ b/lib/guard/sunspot/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module SunspotVersion
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end


### PR DESCRIPTION
Gets rid of annoying deprecation warning.
