### PR TITLE
Support Guard 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+coverage/*

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ $ guard init sunspot
 
 ## Options
 You can set RAILS\_ENV by setting the  `:environment` option.
+You can use bundler by setting the  `:bundler` option. The default is false.
+You can use zeus by setting the  `:bundler` option. The default is false.
 
 ```ruby
-guard 'sunspot', :environment => 'development' do
+guard 'sunspot', :environment => 'development', :bundler => true, :zeus => false do
   watch('Gemfile.lock')
   watch('config/sunspot.yml')
 end

--- a/guard-sunspot.gemspec
+++ b/guard-sunspot.gemspec
@@ -10,17 +10,19 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/cleanoffer/guard-sunspot"
   s.summary     = 'Guard gem for sunspot solr'
   s.description = 'Guard::Sunspot automatically starts and stops your solr server.'
+  s.license     = 'MIT'
 
   s.rubyforge_project = "guard-sunspot"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.files        = Dir.glob('{lib}/**/*') + %w[LICENSE Readme.md]
+  s.require_path = 'lib'
 
-  # specify any dependencies here; for example:
-  # s.add_development_dependency "rspec"
-  # s.add_runtime_dependency "rest-client"
-  s.add_runtime_dependency "guard"
-  s.add_runtime_dependency "sunspot_solr"
+  s.add_dependency 'guard', '>= 2.0'
+  s.add_dependency('guard-compat', '~> 0.3')
+  s.add_dependency "sunspot_solr"
+
+  s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency 'timecop'
+  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'poltergeist'
 end

--- a/guard-sunspot.gemspec
+++ b/guard-sunspot.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "guard-sunspot"
 
-  s.files        = Dir.glob('{lib}/**/*') + %w[LICENSE Readme.md]
+  s.files        = Dir.glob('{lib}/**/*') + %w[LICENSE README.md]
   s.require_path = 'lib'
 
   s.add_dependency 'guard', '>= 2.0'

--- a/guard-sunspot.gemspec
+++ b/guard-sunspot.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob('{lib}/**/*') + %w[LICENSE README.md]
   s.require_path = 'lib'
 
-  s.add_dependency 'guard', '>= 2.0'
-  s.add_dependency('guard-compat', '~> 0.3')
+  s.add_dependency 'guard', '~> 2.0'
+  s.add_dependency 'guard-compat', '~> 1.1'
   s.add_dependency "sunspot_solr"
 
   s.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/guard/sunspot.rb
+++ b/lib/guard/sunspot.rb
@@ -1,13 +1,12 @@
-require "guard"
-require "guard/guard"
+require 'guard/compat/plugin'
 require "guard/sunspot/version"
 
 module Guard
-  class Sunspot < Guard
-    def initialize(watchers=[], options={})
+  class Sunspot < Plugin
+    def initialize(options={})
       super
 
-      @environment = options[:environment] || 'development'
+      @environment = options.fetch(:environment, 'development')
       @bundler = options.fetch(:bundler, false)
       @zeus = options.fetch(:zeus, false)
     end
@@ -27,9 +26,11 @@ module Guard
       start
     end
 
-    def run_on_change(path)
+    def run_on_changes(path)
       reload
     end
+    # for guard 1.0.x and earlier
+    alias :run_on_change :run_on_changes
 
     private
 

--- a/lib/guard/sunspot.rb
+++ b/lib/guard/sunspot.rb
@@ -9,15 +9,16 @@ module Guard
 
       @environment = options[:environment] || 'development'
       @bundler = options.fetch(:bundler, false)
+      @zeus = options.fetch(:zeus, false)
     end
 
     def start
-      system "#{command_prefix} rake sunspot:solr:start RAILS_ENV=#{@environment}"
+      system "#{rake} sunspot:solr:start RAILS_ENV=#{@environment}"
       UI.info "Sunspot started"
     end
 
     def stop
-      system "#{command_prefix} rake sunspot:solr:stop RAILS_ENV=#{@environment}"
+      system "#{rake} sunspot:solr:stop RAILS_ENV=#{@environment}"
       UI.info "Sunspot stopped"
     end
 
@@ -32,8 +33,12 @@ module Guard
 
     private
 
-    def command_prefix
-      "bundle exec" if @bundler
+    def rake
+      rake = []
+      rake << "bundle exec" if @bundler
+      rake << "zeus" if @zeus
+      rake << "rake"
+      rake.join ' '
     end
   end
 end

--- a/lib/guard/sunspot.rb
+++ b/lib/guard/sunspot.rb
@@ -8,15 +8,16 @@ module Guard
       super
 
       @environment = options[:environment] || 'development'
+      @bundler = options.fetch(:bundler, false)
     end
 
     def start
-      system("rake sunspot:solr:start RAILS_ENV=#{@environment}")
+      system "#{command_prefix} rake sunspot:solr:start RAILS_ENV=#{@environment}"
       UI.info "Sunspot started"
     end
 
     def stop
-      system("rake sunspot:solr:stop RAILS_ENV=#{@environment}")
+      system "#{command_prefix} rake sunspot:solr:stop RAILS_ENV=#{@environment}"
       UI.info "Sunspot stopped"
     end
 
@@ -27,6 +28,12 @@ module Guard
 
     def run_on_change(path)
       reload
+    end
+
+    private
+
+    def command_prefix
+      "bundle exec" if @bundler
     end
   end
 end

--- a/spec/guard/sunspot_spec.rb
+++ b/spec/guard/sunspot_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+describe Guard::Sunspot do
+  let(:options) { {} }
+  let(:plugin_instance) { described_class.new(options) }
+
+  before do
+    # Silence UI.info output
+    allow(::Guard::UI).to receive(:info).and_return(true)
+    allow(::Guard::Notifier).to receive(:notify).and_return(true)
+  end
+
+  describe '#initialize' do
+    subject { plugin_instance }
+
+    context 'when the bundler option is specified' do
+      let(:options) { {bundler: true} }
+      it 'stores the option' do
+        expect(subject.instance_variable_get(:@bundler)).to eq(true)
+      end
+      it 'sets the zeus option to false' do
+        expect(subject.instance_variable_get(:@zeus)).to eq(false)
+      end
+    end
+
+    context 'when the zeus option is specified' do
+      let(:options) { {zeus: true} }
+      it 'stores the option as true' do
+        expect(subject.instance_variable_get(:@zeus)).to eq(true)
+      end
+      it 'sets the bundler option to false' do
+        expect(subject.instance_variable_get(:@bundler)).to eq(false)
+      end
+    end
+
+    context 'when an environment is specified' do
+      let(:options) { {environment: 'foo'} }
+      it 'stores the environment' do
+        expect(subject.instance_variable_get(:@environment)).to eq('foo')
+      end
+    end
+
+    context 'when no environment is specified' do
+      it 'defaults to "development"' do
+        expect(subject.instance_variable_get(:@environment)).to eq('development')
+      end
+    end
+  end
+
+  describe '#start' do
+    it 'makes a system call to start solr' do
+      expect(plugin_instance).to receive(:system).with(/sunspot:solr:start/)
+      plugin_instance.start
+    end
+  end
+
+  describe '#stop' do
+    it 'makes a system call to stop solr' do
+      expect(plugin_instance).to receive(:system).with(/sunspot:solr:stop/)
+      plugin_instance.stop
+    end
+  end
+
+  describe '#reload' do
+    it 'calls stop then start' do
+      expect(plugin_instance).to receive(:stop).ordered
+      expect(plugin_instance).to receive(:start).ordered
+      plugin_instance.reload
+    end
+  end
+
+  describe '#run_on_change (for guard 1.0.x and earlier)' do
+    it 'calls reload' do
+      expect(plugin_instance).to receive(:reload)
+      plugin_instance.run_on_change('/file')
+    end
+  end
+
+  describe '#run_on_changes' do
+    it 'calls reload' do
+      expect(plugin_instance).to receive(:reload)
+      plugin_instance.run_on_change('/file')
+    end
+  end
+
+  describe '#rake' do
+    subject { plugin_instance.send(:rake) }
+    context "when bundler is enabled" do
+      let(:options) { {bundler: true} }
+      it { is_expected.to eq('bundle exec rake') }
+    end
+
+    context "when zeus is enabled" do
+      let(:options) { {zeus: true} }
+      it { is_expected.to eq('zeus rake') }
+    end
+
+    context "when neither are enabled" do
+      it { is_expected.to eq('rake') }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+# -*- encoding : utf-8 -*-
+unless ENV['CI']
+  require 'simplecov'
+  SimpleCov.start do
+    add_group 'Guard::Sunspot', 'lib/sunspot'
+    add_group 'Specs', 'spec'
+  end
+end
+
+require 'rspec'
+require 'timecop'
+require 'guard/compat/test/helper'
+require 'guard/sunspot'
+
+ENV["GUARD_ENV"] = 'test'


### PR DESCRIPTION
_This branch is build on top of #4, which adds support for Bundler and Zeus. So #4 should be merged before this PR._

Use Guard's `Plugin` class. Add basic rspecs to this project. Update the gemspec to follow "modern" convention. Add specs to the project. Also, add the license (already in the project in its own file) to the gemspec.
